### PR TITLE
IngramMicro::Transmission uses `TRANSMISSION_FILENAME` instead of `transaction-name` in `#schema_valid?`

### DIFF
--- a/lib/ingram_micro/transmission.rb
+++ b/lib/ingram_micro/transmission.rb
@@ -19,7 +19,7 @@ class IngramMicro::Transmission
 
   def schema_valid?
     xsd = Nokogiri::XML::Schema(File.read("#{IngramMicro::GEM_DIR}/xsd/" +
-      XSD[self.transaction_name]))
+      XSD[self.class::TRANSMISSION_FILENAME]))
     valid = true
     xsd.validate(self.xml_builder.doc).each do |error|
       errors << error.message

--- a/lib/ingram_micro/transmissions/check_shipment_status.rb
+++ b/lib/ingram_micro/transmissions/check_shipment_status.rb
@@ -1,4 +1,5 @@
 class IngramMicro::CheckShipmentStatus < IngramMicro::Transmission
+  TRANSMISSION_FILENAME = 'shipment-status'
 
   attr_accessor :business_name, :customer_id, :line_items
 

--- a/lib/ingram_micro/transmissions/return_authorization.rb
+++ b/lib/ingram_micro/transmissions/return_authorization.rb
@@ -1,4 +1,6 @@
 class IngramMicro::ReturnAuthorization < IngramMicro::Transmission
+  TRANSMISSION_FILENAME = 'return-authorization'
+
   attr_accessor :customer, :credit_card_information, :order_header,
   :shipment_information, :detail, :purchase_order_information
 

--- a/lib/ingram_micro/transmissions/sales_order.rb
+++ b/lib/ingram_micro/transmissions/sales_order.rb
@@ -1,4 +1,6 @@
 class IngramMicro::SalesOrder < IngramMicro::Transmission
+  TRANSMISSION_FILENAME = 'sales-order-submission'
+
   attr_accessor :customer, :credit_card_information, :sales_order_header,
   :sales_order_shipment_information, :detail, :carrier_name, :business_name,
   :customer_id

--- a/lib/ingram_micro/transmissions/standard_response.rb
+++ b/lib/ingram_micro/transmissions/standard_response.rb
@@ -1,4 +1,6 @@
 class IngramMicro::StandardResponse < IngramMicro::Transmission
+  TRANSMISSION_FILENAME = 'standard-response'
+  
   attr_accessor :status_code, :status_description, :comments,
     :response_timestamp, :filename, :transaction_name
 


### PR DESCRIPTION


[#127184141]