### PR TITLE
IMM gem updates: line item & outbound shipment info

### DIFF
--- a/lib/ingram_micro/elements/sales_order_line_item.rb
+++ b/lib/ingram_micro/elements/sales_order_line_item.rb
@@ -1,4 +1,5 @@
 class IngramMicro::SalesOrderLineItem < IngramMicro::BaseElement
+  attr_reader :line_name_value
 
   DEFAULTS = {
     :line_no => nil,
@@ -23,6 +24,31 @@ class IngramMicro::SalesOrderLineItem < IngramMicro::BaseElement
     :line_tax3 => 0.0
   }
 
+  INTL_DEFAULTS = {
+    line_no: nil,
+    item_code: nil,
+    universal_product_code: nil,
+    product_name: nil,
+    comments: nil,
+    quantity: 1.0,
+    unit_of_measure: nil,
+    sid: nil,
+    esn: nil,
+    min: nil,
+    mdn: nil,
+    irdb: nil,
+    imei: nil,
+    market_id: nil,
+    line_status: nil,
+    base_price: 0.0,
+    line_discount: 0.0,
+    line_tax1: 0.0,
+    line_tax2: 0.0,
+    line_tax3: 0.0,
+    special_message: nil,
+    line_name_value: []
+  }.freeze
+
   def line_no
     @element[:line_no]
   end
@@ -32,6 +58,41 @@ class IngramMicro::SalesOrderLineItem < IngramMicro::BaseElement
   end
 
   def defaults
-    DEFAULTS
+    IngramMicro.domestic_shipping? ? DEFAULTS : INTL_DEFAULTS
+  end
+
+  def build(builder)
+    # Similar to BaseElement except we want to skip special_message and
+    # line_name_value and handle them differently.
+    defaults.keys.each do |field|
+      next if [:special_message, :line_name_value].include?(field)
+      element_name = field.to_s.tr('_', '-')
+      element_value = formatted_value_of(field)
+      builder.send(element_name, element_value)
+    end
+    add_special_message(builder)
+    # Expect that line_name_value will be an array of arrays, each of which
+    # contains a name and value that will translate to line-attribute-name and
+    # line-attribute-value.
+    element[:line_name_value].each do |pair|
+      attr_name, attr_value = pair
+      add_line_name_value(attr_name, attr_value, builder)
+    end
+  end
+
+  # The <line-name-value> element in the detail of a sales order line item
+  # is used for information related to international shipments. There can be
+  # multiple line-name-value elements. See SalesOrderLineItemNameValue.
+  def add_line_name_value(name, value, builder)
+    SalesOrderLineItemNameValue.new(name: name, value: value).build(builder)
+  end
+
+  # The <special-message> element is optional, including some information
+  # pertaining to international shipments. An instance of the class
+  # IngramMicro::SalesOrderLineItemSpecialMessage is passed in on
+  # initialization to make this work.
+  def add_special_message(builder)
+    message = element[:special_message]
+    message.build(builder) if message
   end
 end

--- a/lib/ingram_micro/elements/sales_order_line_item_name_value.rb
+++ b/lib/ingram_micro/elements/sales_order_line_item_name_value.rb
@@ -1,0 +1,33 @@
+module IngramMicro
+  class SalesOrderLineItemNameValue < BaseElement
+    ACCEPTABLE_ATTRIBUTE_NAMES = [
+      "international-eccn-value",
+      "international-declared-value",
+      "warranty-item",
+      "international-country-of-origin",
+      "international-license-value",
+      "hts-code"
+    ].freeze
+
+    DEFAULTS = {
+      :name => nil,
+      :value => nil
+    }.freeze
+
+    def build(builder)
+      name, value = element[:name], element[:value]
+      if ACCEPTABLE_ATTRIBUTE_NAMES.include?(name)
+        builder.send('line-name-value') do
+          builder.send('line-attribute-name', name)
+          builder.send('line-attribute-value', value)
+        end
+      else
+        raise ArgumentError, "Invalid attribute name: #{name}"
+      end
+    end
+
+    def defaults
+      DEFAULTS
+    end
+  end
+end

--- a/lib/ingram_micro/elements/sales_order_line_item_special_message.rb
+++ b/lib/ingram_micro/elements/sales_order_line_item_special_message.rb
@@ -1,0 +1,28 @@
+module IngramMicro
+  class SalesOrderLineItemSpecialMessage < BaseElement
+    DEFAULTS = {
+      engraving_location: nil,
+      engraving_font: nil,
+      special_message1: nil,
+      special_message2: nil,
+      special_message3: nil,
+      special_message4: nil,
+      special_message5: nil,
+      special_message6: nil
+    }.freeze
+
+    def build(builder)
+      el_copy = element
+      builder.send('special-message') do
+        el_copy.each do |field, value|
+          field_name = field.to_s.tr("_", "-")
+          builder.send(field_name, value) unless value.nil?
+        end
+      end
+    end
+
+    def defaults
+      DEFAULTS
+    end
+  end
+end

--- a/spec/ingram_micro/elements/sales_order_line_item_name_value_spec.rb
+++ b/spec/ingram_micro/elements/sales_order_line_item_name_value_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+describe IngramMicro::SalesOrderLineItemNameValue do
+  let(:builder) { Nokogiri::XML::Builder.new }
+
+  describe '#self. build' do
+
+    it 'raises an error with an invalid attribute name passed in' do
+      name, value = 'Joseph', 'is the best'
+      linv = described_class.new(name: name, value: value)
+      expect{linv.build(builder)}.to raise_error(ArgumentError)
+    end
+
+    it 'works fine with a valid attribute name' do
+      name, value = 'warranty-item', 'true'
+      linv = described_class.new(name: name, value: value)
+
+      expect{linv.build(builder)}.to_not raise_error
+    end
+
+    it 'properly creates xml' do
+      test_builder = Nokogiri::XML::Builder.new
+      linv1 = described_class.new(name: 'international-eccn-value', value: '30.00')
+      linv2 = described_class.new(name: 'hts-code', value: '42')
+      test_builder.send('line-item') do
+        linv1.build(test_builder)
+        linv2.build(test_builder)
+      end
+
+      expect(test_builder.to_xml).to include('<line-attribute-name>international-eccn-value')
+      expect(test_builder.to_xml).to include('<line-attribute-value>42')
+    end
+  end
+
+end

--- a/spec/ingram_micro/elements/sales_order_line_item_spec.rb
+++ b/spec/ingram_micro/elements/sales_order_line_item_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+
+describe IngramMicro::SalesOrderLineItem do
+  let(:line_item) { Fabricate.build(:sales_order_line_item) }
+
+  describe '#line_no and #line_no=' do
+    it 'Gets the line_no' do
+      expect(line_item.line_no).to eq 1
+    end
+
+    it "Sets the line_no" do
+      line_item.element[:line_no] = 4
+
+      expect(line_item.line_no).to eq 4
+    end
+  end
+
+  describe '#add_line_name_value' do
+    let(:line_attr_name) { 'international-declared-value' }
+    let(:line_attr_value) { '1999' }
+
+    context 'called explicitly' do
+      let(:builder) { Nokogiri::XML::Builder.new }
+      let!(:line_name_value_xml) { line_item.add_line_name_value(line_attr_name, line_attr_value, builder).build }
+      it "passes information to the line-name-value" do
+        expect(builder.to_xml).to include('<line-attribute-name>international-declared')
+        expect(builder.to_xml).to include('<line-attribute-value>1999</line-attribute-value>')
+      end
+    end
+
+    context 'called as part of #build' do
+      let(:blankli) { described_class.new }
+      context 'when no name-value pairs are present' do
+        it 'does not get called if no name-value pairs are present' do
+          builder = Nokogiri::XML::Builder.new
+          expect(blankli).to_not receive(:add_line_name_value)
+
+          builder.send('message') do
+            (blankli.build(builder))
+          end
+        end
+      end
+
+      # For some reason, using let(:builder) and let(:li) for this context does
+      # not work the same way as defining them in each it block.
+      # Furthermore, the expectation that li would receive :add_line_name_value
+      # appears to prevent the method from actually being called, which means
+      # the resulting xml won't appear unless it is called in a separate test.
+      context 'when at least one attribute-value pair is present' do
+        it 'gets called' do
+          li = described_class.new(line_name_value: [["international-license-value",'300.50']])
+          builder = Nokogiri::XML::Builder.new
+          expect(li).to receive(:add_line_name_value)
+          builder.send('message') do
+            li.build(builder)
+          end
+        end
+
+        it 'properly creates xml' do
+          li = described_class.new(product_name: "killerizer", line_name_value: [["international-license-value",'300.50']])
+          builder = Nokogiri::XML::Builder.new
+          builder.send('message') do
+            li.build(builder)
+          end
+          expect(builder.to_xml).to include('<line-attribute-name>international-license-value')
+          expect(builder.to_xml).to include('<line-attribute-value>300.50')
+        end
+      end
+    end
+  end
+
+  describe '#add_special_message' do
+    it 'does not create a new special message object if nothing is passed in' do
+      builder = Nokogiri::XML::Builder.new
+      li = described_class.new
+      builder.send('message') do
+        li.build(builder)
+      end
+      expect(builder.to_xml).to_not include('<special-message/>')
+    end
+    it 'adds a special message to the xml if one is passed in' do
+      builder = Nokogiri::XML::Builder.new
+      message = IngramMicro::SalesOrderLineItemSpecialMessage.new(
+        engraving_font: 'hellavetica',
+        engraving_location: 'Santa Cruz',
+        special_message1: 'duuuude'
+      )
+      li = described_class.new(special_message: message)
+      builder.send('message') do
+        li.build(builder)
+      end
+      expect(builder.to_xml).to include('<special-message>')
+      expect(builder.to_xml).to include('<engraving-font>hellavetica')
+    end
+  end
+end

--- a/spec/ingram_micro/elements/sales_order_line_item_special_message_spec.rb
+++ b/spec/ingram_micro/elements/sales_order_line_item_special_message_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe IngramMicro::SalesOrderLineItemSpecialMessage do
+  context 'without any information passed in' do
+    it "produces a 'special-message' xml field" do
+      special_message = described_class.new
+      builder = Nokogiri::XML::Builder.new
+
+      expect(special_message.build(builder)).to be_truthy
+      expect(builder.to_xml).to include("<special-message/>")
+    end
+  end
+
+  context 'with information passed in' do
+    let(:message_options) {
+      {
+        engraving_font: 'hellavetica',
+        engraving_location: 'Santa Cruz',
+        special_message1: 'duuuude'
+      }
+    }
+    let(:message) { described_class.new(message_options) }
+
+    it 'sets the fields accordingly' do
+      expect(message.element[:engraving_font]).to eq("hellavetica")
+      expect(message.element[:special_message1]).to eq("duuuude")
+      expect(message.element[:special_message4]).to be nil
+    end
+
+    it 'creates xml properly' do
+      builder = Nokogiri::XML::Builder.new
+      message.build(builder)
+
+      expect(builder.to_xml).to include('<engraving-font>hellavetica')
+      expect(builder.to_xml).to include('<special-message1>duuuude')
+      expect(builder.to_xml).to_not include('<special-message4>')
+    end
+  end
+end


### PR DESCRIPTION
- Adds `INTL_DEFAULTS` to `SalesOrderLineItem`
- Add `SalesOrderLineItemNameValue` and `SalesOrderLineItemSpecialMessage` classes

[#130254531]
