### PR TITLE
Refactor line-item-name-value and header-name-value

### DIFF
--- a/lib/ingram_micro/elements/sales_order_header.rb
+++ b/lib/ingram_micro/elements/sales_order_header.rb
@@ -40,7 +40,7 @@ module IngramMicro
       gift_flag: nil,
       packing_slip_format: nil,
       special_header_message: nil,
-      header_name_value: []
+      header_name_value: {}
     }.freeze
 
     def defaults
@@ -56,16 +56,15 @@ module IngramMicro
         element_value = formatted_value_of(field)
         builder.send(element_name, element_value)
       end
-      add_header_name_values(builder) unless IngramMicro.domestic_shipping?
+      add_header_name_value(builder) unless IngramMicro.domestic_shipping?
     end
 
-    # Assume that element[:header_name_value] will be an array of arrays, with
-    # each inner array a pair of strings, [name, value].
-    def add_header_name_values(builder)
-      element[:header_name_value].each do |pair|
-        name, value = pair
-        SalesOrderHeaderNameValue.new(name: name, value: value).build(builder)
-      end
+    # Assume that element[:header_name_value] will be a hash with options to be
+    # passed to the header-name-value element. See SalesOrderHeaderNameValue
+    # for more information.
+    def add_header_name_value(builder)
+      options = element[:header_name_value] || {}
+      header_name_value = SalesOrderHeaderNameValue.new(options).build(builder)
     end
   end
 end

--- a/lib/ingram_micro/elements/sales_order_header_name_value.rb
+++ b/lib/ingram_micro/elements/sales_order_header_name_value.rb
@@ -1,25 +1,29 @@
 module IngramMicro
   class SalesOrderHeaderNameValue < BaseElement
-    HEADER_ATTRIBUTE_NAMES = [
-      "international-duties-and-taxes-billing-to",
-      "international-freight-billing-to",
-      "international-freight-account",
-      "international-incoterm",
-      "international-importer-of-record-email",
-      "international-importer-of-record-phone-number",
-      "international-importer-of-record-country-code",
-      "international-importer-of-record-zipcode",
-      "international-importer-of-record-state",
-      "international-importer-of-record-city",
-      "international-importer-of-record-address3",
-      "international-importer-of-record-address2",
-      "international-importer-of-record-address1",
-      "international-importer-of-record-name"
-    ].freeze
+
+    # Each key in DEFAULTS maps to a valid attribute-name for this element.
+    # Values are passed in via the options hash.
+    # For example, if the options include {international_incoterm: 'ABC'}, you'll get:
+    # <header-name-value>
+    #   <attribute-name>international-incoterm</attribute-name>
+    #   <attribute-value>'ABC'</attribute-value>
+    # </header-name-value>
 
     DEFAULTS = {
-      name: nil,
-      value: nil
+      international_duties_and_taxes_billing_to: nil,
+      international_freight_billing_to: nil,
+      international_freight_account: nil,
+      international_incoterm: nil,
+      international_importer_of_record_email: nil,
+      international_importer_of_record_phone_number: nil,
+      international_importer_of_record_country_code: nil,
+      international_importer_of_record_zipcode: nil,
+      international_importer_of_record_state: nil,
+      international_importer_of_record_city: nil,
+      international_importer_of_record_address3: nil,
+      international_importer_of_record_address2: nil,
+      international_importer_of_record_address1: nil,
+      international_importer_of_record_name: nil
     }.freeze
 
     def defaults
@@ -27,14 +31,12 @@ module IngramMicro
     end
 
     def build(builder)
-      if HEADER_ATTRIBUTE_NAMES.include?(element[:name])
-        name, value = element[:name], element[:value]
+      element.each do |field, value|
+        xml_name = field.to_s.tr("_","-")
         builder.send('header-name-value') do
-          builder.send('attribute-name', name)
+          builder.send('attribute-name', xml_name)
           builder.send('attribute-value', value)
         end
-      else
-        raise ArgumentError, "Header attribute #{name} is invalid."
       end
     end
   end

--- a/lib/ingram_micro/elements/sales_order_line_item.rb
+++ b/lib/ingram_micro/elements/sales_order_line_item.rb
@@ -2,26 +2,26 @@ module IngramMicro
   class SalesOrderLineItem < BaseElement
 
     DEFAULTS = {
-      :line_no => nil,
-      :item_code => nil,
-      :universal_product_code => nil,
-      :product_name => nil,
-      :comments => nil,
-      :quantity => 1.0,
-      :unit_of_measure => nil,
-      :sid => nil,
-      :esn => nil,
-      :min => nil,
-      :mdn => nil,
-      :irdb => nil,
-      :imei => nil,
-      :market_id => nil,
-      :line_status => nil,
-      :base_price => 0.0,
-      :line_discount => 0.0,
-      :line_tax1 => 0.0,
-      :line_tax2 => 0.0,
-      :line_tax3 => 0.0
+      line_no: nil,
+      item_code: nil,
+      universal_product_code: nil,
+      product_name: nil,
+      comments: nil,
+      quantity: 1.0,
+      unit_of_measure: nil,
+      sid: nil,
+      esn: nil,
+      min: nil,
+      mdn: nil,
+      irdb: nil,
+      imei: nil,
+      market_id: nil,
+      line_status: nil,
+      base_price: 0.0,
+      line_discount: 0.0,
+      line_tax1: 0.0,
+      line_tax2: 0.0,
+      line_tax3: 0.0
     }.freeze
 
     INTL_DEFAULTS = {
@@ -46,7 +46,7 @@ module IngramMicro
       line_tax2: 0.0,
       line_tax3: 0.0,
       special_message: nil,
-      line_name_value: []
+      line_name_value: {}
     }.freeze
 
     def line_no
@@ -65,13 +65,12 @@ module IngramMicro
       # Similar to BaseElement except we want to skip special_message and
       # line_name_value and handle them differently.
       defaults.keys.each do |field|
-
         next if [:special_message, :line_name_value].include?(field)
         element_name = field.to_s.tr('_', '-')
         element_value = formatted_value_of(field)
         builder.send(element_name, element_value)
       end
-      add_special_message(builder)
+      add_special_message(builder) if element[:special_message]
       # If this is an international shipment, then we need to add line-name-value
       # to the xml. Otherwise we can skip that.
       add_line_name_value(builder) unless IngramMicro.domestic_shipping?
@@ -79,21 +78,15 @@ module IngramMicro
 
     # The <line-name-value> element in the detail of a sales order line item
     # is used for information related to international shipments. There can be
-    # multiple line-name-value elements.
-    # element[:line_name_value] is an array of arrays, where each inner array
-    # is a pair of line-attribute-name and line-attribute-value.
-    # See SalesOrderLineItemNameValue.
+    # multiple line-name-value elements. If using the iternational schema but
+    # shipping domestically, these fields will be blank.
+    # element[:line_name_value] a hash with options that become line-name-value
+    # elements.
+    # See SalesOrderLineItemNameValue for more.
     def add_line_name_value(builder)
-      element[:line_name_value].each do |pair|
-        name, value = pair
-        SalesOrderLineItemNameValue.new(name: name, value: value).build(builder)
-      end
+      SalesOrderLineItemNameValue.new(element[:line_name_value]).build(builder)
     end
 
-    # The <special-message> element is optional, including some information
-    # pertaining to international shipments. An instance of the class
-    # IngramMicro::SalesOrderLineItemSpecialMessage is passed in on
-    # initialization to make this work.
     def add_special_message(builder)
       message = element[:special_message]
       message.build(builder) if message

--- a/lib/ingram_micro/elements/sales_order_line_item_name_value.rb
+++ b/lib/ingram_micro/elements/sales_order_line_item_name_value.rb
@@ -1,33 +1,34 @@
 module IngramMicro
   class SalesOrderLineItemNameValue < BaseElement
-    ACCEPTABLE_ATTRIBUTE_NAMES = [
-      "international-eccn-value",
-      "international-declared-value",
-      "warranty-item",
-      "international-country-of-origin",
-      "international-license-value",
-      "hts-code"
-    ].freeze
 
+    # Each key in DEFAULTS maps to a valid line-attribute-name for this element.
+    # Values are passed in via the options hash.
+    # For example, if the options include {warranty_item: 'true'}, you'll get:
+    # <line-name-value>
+    #   <line-attribute-name>warranty-item</line-attribute-name>
+    #   <line-attribute-value>true</line-attribute-value>
+    # </line-name-value>
     DEFAULTS = {
-      :name => nil,
-      :value => nil
-    }.freeze
-
-    def build(builder)
-      name, value = element[:name], element[:value]
-      if ACCEPTABLE_ATTRIBUTE_NAMES.include?(name)
-        builder.send('line-name-value') do
-          builder.send('line-attribute-name', name)
-          builder.send('line-attribute-value', value)
-        end
-      else
-        raise ArgumentError, "Invalid attribute name: #{name}"
-      end
-    end
+      international_eccn_value: nil,
+      international_declared_value: nil,
+      warranty_item: nil,
+      international_country_of_origin: nil,
+      international_license_value: nil,
+      hts_code: nil
+    }
 
     def defaults
       DEFAULTS
+    end
+
+    def build(builder)
+      element.each do |field, value|
+        xml_name = field.to_s.tr("_","-")
+        builder.send('line-name-value') do
+          builder.send('line-attribute-name', xml_name)
+          builder.send('line-attribute-value', value)
+        end
+      end
     end
   end
 end

--- a/spec/fabricators/sales_order_header_international.rb
+++ b/spec/fabricators/sales_order_header_international.rb
@@ -7,21 +7,21 @@ Fabricator(:sales_order_header_international, class_name: IngramMicro::SalesOrde
     order_tax1: Faker::Commerce.price,
     order_tax2: Faker::Commerce.price,
     order_tax3: Faker::Commerce.price,
-    header_name_value:[
-      ["international-duties-and-taxes-billing-to", %w(E I C).sample],
-      ["international-freight-billing-to", Faker::Company.name],
-      ["international-freight-account", Faker::Code.isbn.to_s],
-      ["international-incoterm", "ABC"],
-      ["international-importer-of-record-email", Faker::Internet.email],
-      ["international-importer-of-record-phone-number", Faker::PhoneNumber.phone_number],
-      ["international-importer-of-record-country-code", "US"],
-      ["international-importer-of-record-zipcode", Faker::Address.zip],
-      ["international-importer-of-record-state", Faker::Address.state],
-      ["international-importer-of-record-city", Faker::Address.city],
-      ["international-importer-of-record-address3", ""],
-      ["international-importer-of-record-address2", ""],
-      ["international-importer-of-record-address1", Faker::Address.street_address],
-      ["international-importer-of-record-name", Faker::Name.first_name]
-    ]
+    header_name_value: {
+      international_duties_and_taxes_billing_to: %w(E I C).sample,
+      international_freight_billing_to: Faker::Company.name,
+      international_freight_account: Faker::Code.isbn.to_s,
+      international_incoterm: "ABC",
+      international_importer_of_record_email: Faker::Internet.email,
+      international_importer_of_record_phone_number: Faker::PhoneNumber.phone_number,
+      international_importer_of_record_country_code: "US",
+      international_importer_of_record_zipcode: Faker::Address.zip,
+      international_importer_of_record_state: Faker::Address.state,
+      international_importer_of_record_city: Faker::Address.city,
+      international_importer_of_record_address3: "",
+      international_importer_of_record_address2: "",
+      international_importer_of_record_address1: Faker::Address.street_address,
+      international_importer_of_record_name: Faker::Name.first_name
+    }
   }}
 end

--- a/spec/fabricators/sales_order_line_item_international.rb
+++ b/spec/fabricators/sales_order_line_item_international.rb
@@ -19,13 +19,13 @@ Fabricator(:sales_order_line_item_international, class_name: IngramMicro::SalesO
              line_tax1: Faker::Commerce.price,
              line_tax2: Faker::Commerce.price,
              line_tax3: Faker::Commerce.price,
-             line_name_value: [
-               ["international-eccn-value", "1A001"],
-               ["international-declared-value", Faker::Commerce.price],
-               ["warranty-item", "false"],
-               ["international-country-of-origin", Faker::Address.country_code],
-               ["international-license-value", Faker::Commerce.price],
-               ["hts-code", "0000.00000.00"]
-             ]
+             line_name_value: {
+               international_eccn_value: "1A001",
+               international_declared_value: Faker::Commerce.price,
+               warranty_item: "false",
+               international_country_of_origin: Faker::Address.country_code,
+               international_license_value: Faker::Commerce.price,
+               hts_code: "0000.00000.00"
+             }
               }}
 end

--- a/spec/ingram_micro/elements/sales_order_header_name_value_spec.rb
+++ b/spec/ingram_micro/elements/sales_order_header_name_value_spec.rb
@@ -2,26 +2,51 @@ require 'spec_helper'
 
 describe IngramMicro::SalesOrderHeaderNameValue do
   describe '#build' do
-    let(:builder) { Nokogiri::XML::Builder.new }
-    context 'with invalid names passed in' do
-      bad_names = described_class.new(name: 'blah', value: 'blah')
-
-      it 'raises an error' do
-        expect{bad_names.build(builder)}.to raise_error(ArgumentError)
-      end
-    end
 
     context 'with valid name passed in' do
-      good_name = "international-importer-of-record-city"
-      good_name_value = described_class.new(name: good_name, value: 'Amsterdam')
+      good_name_value = described_class.new(international_importer_of_record_city: "Amsterdam")
+
       it 'successfully passes in values' do
-        expect{good_name_value.build(builder)}.to_not raise_error
+        builder = Nokogiri::XML::Builder.new
+        expect do
+          builder.send('message') do
+            good_name_value.build(builder)
+          end
+        end.to_not raise_error
       end
+
       it 'creates the correct xml elements' do
-        good_name_value.build(builder)
+        builder = Nokogiri::XML::Builder.new
+        builder.send('message') do
+          good_name_value.build(builder)
+        end
+
         expect(builder.to_xml).to include('<attribute-name>international-importer-of-record-city')
         expect(builder.to_xml).to include('<attribute-value>Amsterdam</attribute-value>')
       end
     end
   end
+  # describe '#build' do
+  #   let(:builder) { Nokogiri::XML::Builder.new }
+  #   context 'with invalid names passed in' do
+  #     bad_names = described_class.new(name: 'blah', value: 'blah')
+  #
+  #     it 'raises an error' do
+  #       expect{bad_names.build(builder)}.to raise_error(ArgumentError)
+  #     end
+  #   end
+  #
+  #   context 'with valid name passed in' do
+  #     good_name = "international-importer-of-record-city"
+  #     good_name_value = described_class.new(name: good_name, value: 'Amsterdam')
+  #     it 'successfully passes in values' do
+  #       expect{good_name_value.build(builder)}.to_not raise_error
+  #     end
+  #     it 'creates the correct xml elements' do
+  #       good_name_value.build(builder)
+  #       expect(builder.to_xml).to include('<attribute-name>international-importer-of-record-city')
+  #       expect(builder.to_xml).to include('<attribute-value>Amsterdam</attribute-value>')
+  #     end
+  #   end
+  # end
 end

--- a/spec/ingram_micro/elements/sales_order_header_spec.rb
+++ b/spec/ingram_micro/elements/sales_order_header_spec.rb
@@ -6,6 +6,7 @@ describe IngramMicro::SalesOrderHeader do
 
     context 'when using the domestic schema' do
       it "returns the correct default values hash" do
+        IngramMicro.configuration.international = false
         so_defaults = IngramMicro::SalesOrderHeader.new.defaults
 
         expect(so_defaults.keys.count).to eq 12
@@ -59,11 +60,13 @@ describe IngramMicro::SalesOrderHeader do
   end
 
   describe "#add_header_name_values" do
+    IngramMicro.configuration.international = true
     it 'allows header-name-value to be passed in' do
       soh_options = {
         customer_order_number: 2083648614,
         order_total_net: 39.46,
-        header_name_value: [["international-importer-of-record-email", "email@canada.ca"]]
+        header_name_value: {international_importer_of_record_email: "email@canada.ca"}
+        # header_name_value: [["international-importer-of-record-email", "email@canada.ca"]]
       }
       soh_builder = Nokogiri::XML::Builder.new do |builder|
         builder.send('message') do

--- a/spec/ingram_micro/elements/sales_order_line_item_name_value_spec.rb
+++ b/spec/ingram_micro/elements/sales_order_line_item_name_value_spec.rb
@@ -5,26 +5,24 @@ describe IngramMicro::SalesOrderLineItemNameValue do
 
   describe '#self. build' do
 
-    it 'raises an error with an invalid attribute name passed in' do
-      name, value = 'Joseph', 'is the best'
-      linv = described_class.new(name: name, value: value)
-      expect{linv.build(builder)}.to raise_error(ArgumentError)
-    end
+    it 'allows attributes to be passed in' do
+      linv = described_class.new(warranty_item: 'true')
 
-    it 'works fine with a valid attribute name' do
-      name, value = 'warranty-item', 'true'
-      linv = described_class.new(name: name, value: value)
-
-      expect{linv.build(builder)}.to_not raise_error
+      expect do
+        builder.send('message') do
+          linv.build(builder)
+        end
+      end.to_not raise_error
     end
 
     it 'properly creates xml' do
       test_builder = Nokogiri::XML::Builder.new
-      linv1 = described_class.new(name: 'international-eccn-value', value: '30.00')
-      linv2 = described_class.new(name: 'hts-code', value: '42')
+      linv = described_class.new(
+        international_eccn_value: '30.00',
+        hts_code: '42'
+      )
       test_builder.send('line-item') do
-        linv1.build(test_builder)
-        linv2.build(test_builder)
+        linv.build(test_builder)
       end
 
       expect(test_builder.to_xml).to include('<line-attribute-name>international-eccn-value')

--- a/spec/ingram_micro/elements/sales_order_line_item_spec.rb
+++ b/spec/ingram_micro/elements/sales_order_line_item_spec.rb
@@ -44,7 +44,7 @@ describe IngramMicro::SalesOrderLineItem do
 
         context 'when at least one attribute-value pair is present' do
           it 'gets called' do
-            li = described_class.new(line_name_value: [["international-license-value",'300.50']])
+            li = described_class.new(line_name_value: {international_license_value: '300.50'})
             builder = Nokogiri::XML::Builder.new
 
             expect(li).to receive(:add_line_name_value)
@@ -54,7 +54,7 @@ describe IngramMicro::SalesOrderLineItem do
           end
 
           it 'properly creates xml' do
-            li = described_class.new(product_name: "killerizer", line_name_value: [["international-license-value",'300.50']])
+            li = described_class.new(product_name: "killerizer", line_name_value: {international_license_value: '300.50'})
             builder = Nokogiri::XML::Builder.new
             builder.send('message') do
               li.build(builder)
@@ -78,6 +78,7 @@ describe IngramMicro::SalesOrderLineItem do
 
       expect(builder.to_xml).to_not include('<special-message/>')
     end
+
     it 'adds a special message to the xml if one is passed in' do
       builder = Nokogiri::XML::Builder.new
       message = IngramMicro::SalesOrderLineItemSpecialMessage.new(


### PR DESCRIPTION
## Refactor LineItemNameValue and HeaderNameValue

Adjust the way they are being built and how they are accepting values. The modified version resembles other Elements, which makes these less confusing, even if they do have some unique behaviors of their own.
## Changes
- refactor `SalesOrderHeaderNameValue` and `SalesOrderHeader` as well as Fabricators and tests for both
- refactor `SalesOrderLineItemNameValue` and `SalesOrderLineItemInternational` as well as Fabricators and tests for both
- add and/or rewrite comments
